### PR TITLE
Fix for md5 hash generation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/upyun/go-sdk.svg?branch=master)](https://travis-ci.org/upyun/go-sdk)
 
-For UPYUN URL purge API, please check out [upyunpurge](blob/master/upyunpurge/README.md).
+For UPYUN URL purge API, please check out [upyunpurge](upyunpurge/README.md).
 
 ### 常量
 ```

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build Status](https://travis-ci.org/upyun/go-sdk.svg?branch=master)](https://travis-ci.org/upyun/go-sdk)
 
+For UPYUN URL purge API, please check out [upyunpurge](blob/master/upyunpurge/README.md).
+
 ### 常量
 ```
 const (

--- a/upyun/upyun.go
+++ b/upyun/upyun.go
@@ -184,7 +184,7 @@ func (u *UpYun) makeContentMD5(value *os.File) (string, error) {
 		if n == 0 {
 			break
 		}
-		hasher.Write(chunk)
+		hasher.Write(chunk[0:n])
 	}
 
 	if _, err := value.Seek(0, 0); err != nil {

--- a/upyunpurge/README.md
+++ b/upyunpurge/README.md
@@ -1,0 +1,37 @@
+#Purpose
+
+With this library, you can call upyun cache refresh API to "purge" the old version of your files out of upyun system. 
+
+#Features
+Because upyun imposes a limit for how many urls one can purge for a minute, this library will send urls in batches and wait for 80 seconds before sending the next batch.
+
+Currently, the limit is 600 URLs per minute, and the batch size is 550.
+
+#How to use
+
+```go
+import (
+    "github.com/luanzhu/go-sdk/upyunpurge"
+    "log"
+    "fmt"
+)
+
+
+func refreshURLs(bucket, username, passwd string, urls []string) {
+	u := NewUpYunPurge(bucket, username, passwd)
+
+	invalidURLs, err := u.RefreshURLs(urls)
+	if err != nil {
+		// err contains the error message returned from server
+		log.Fatal(err)
+	} else {
+		// If there is no error, invalidURLs contains a list of URLs that upyun
+		// cannot process, which usually means that these URLs are not in 
+        // current bucket.
+		fmt.Println(invalidURLs)
+	}
+}
+```
+
+
+

--- a/upyunpurge/purge.go
+++ b/upyunpurge/purge.go
@@ -1,0 +1,153 @@
+package upyunpurge
+
+import (
+	"bytes"
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	endpoint = "http://purge.upyun.com/purge/"
+	timeout  = 60
+)
+
+type UpYunPurge struct {
+	httpClient *http.Client
+
+	Bucket   string
+	Username string
+	Passwd   string
+
+	Timeout int
+}
+
+func stringMD5(s string) (string, error) {
+	hasher := md5.New()
+	if _, err := hasher.Write([]byte(s)); err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+func genRFC1123Date() string { return time.Now().UTC().Format(time.RFC1123) }
+
+func encodeURL(uri string) (string, error) {
+	Url, err := url.Parse(uri)
+	if err != nil {
+		return "", err
+	}
+
+	return Url.String(), nil
+}
+
+func timeoutDialer(timeout int) func(string, string) (net.Conn, error) {
+	return func(network, addr string) (c net.Conn, err error) {
+		c, err = net.DialTimeout(network, addr, time.Duration(timeout)*time.Second)
+		if err != nil {
+			return nil, err
+		}
+		return c, err
+	}
+}
+
+func NewUpYunPurge(bucket, username, passwd string) *UpYunPurge {
+	u := new(UpYunPurge)
+	u.Bucket = bucket
+	u.Username = username
+	u.Passwd = passwd
+
+	u.Timeout = timeout
+
+	u.httpClient = &http.Client{}
+	u.SetTimeout(u.Timeout)
+
+	return u
+}
+
+func (u *UpYunPurge) makeSignature(urls string, date string) (string, error) {
+	passwdMD5, err := stringMD5(u.Passwd)
+	if err != nil {
+		return "", err
+	}
+
+	signature := []string{urls, u.Bucket, date, passwdMD5}
+	signatureString := strings.Join(signature, "&")
+	signatureMD5, err := stringMD5(signatureString)
+	if err != nil {
+		return "", err
+	}
+
+	return signatureMD5, nil
+}
+
+func (u *UpYunPurge) makeAuth(sig string) string {
+	return "UpYun " + u.Bucket + ":" + u.Username + ":" + sig
+}
+
+func (u *UpYunPurge) Version() string { return "0.1.0" }
+
+func (u *UpYunPurge) SetTimeout(t int) {
+	tranport := http.Transport{
+		Dial: timeoutDialer(t),
+	}
+
+	u.httpClient = &http.Client{
+		Transport: &tranport,
+	}
+}
+
+func (u *UpYunPurge) RefreshURLs(urls []string) error {
+	method := "POST"
+
+	urlsString := strings.Join(urls, "\n")
+
+	body := "purge=" + urlsString
+	body, err := encodeURL(body)
+	if err != nil {
+		return err
+	}
+
+	date := genRFC1123Date()
+
+	sig, err := u.makeSignature(urlsString, date)
+	if err != nil {
+		return err
+	}
+
+	auth := u.makeAuth(sig)
+
+	req, err := http.NewRequest(method, endpoint, bytes.NewBufferString(body))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Add("Expect", "")
+	req.Header.Add("Date", date)
+	req.Header.Add("Authorization", auth)
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := u.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	reply, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode == 200 {
+		return nil
+	} else {
+		return fmt.Errorf("%d: %s", resp.StatusCode, string(reply))
+	}
+}

--- a/upyunpurge/purge_test.go
+++ b/upyunpurge/purge_test.go
@@ -1,6 +1,7 @@
 package upyunpurge
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -16,9 +17,11 @@ func TestUpyunPurge(t *testing.T) {
 
 	u := NewUpYunPurge(bucket, username, passwd)
 
-	err := u.RefreshURLs(urls)
+	invalidURLs, err := u.RefreshURLs(urls)
 
 	if err != nil {
 		t.Error(err)
+	} else {
+		fmt.Println(invalidURLs)
 	}
 }

--- a/upyunpurge/purge_test.go
+++ b/upyunpurge/purge_test.go
@@ -1,0 +1,24 @@
+package upyunpurge
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestUpyunPurge(t *testing.T) {
+	bucket := os.Getenv("UPYUN_BUCKET")
+	username := os.Getenv("UPYUN_USERNAME")
+	passwd := os.Getenv("UPYUN_PASSWORD")
+	urlsString := os.Getenv("UPYUN_URLS")
+
+	urls := strings.Split(urlsString, ",")
+
+	u := NewUpYunPurge(bucket, username, passwd)
+
+	err := u.RefreshURLs(urls)
+
+	if err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
I enabled md5 verification this afternoon but I kept getting "Error: 406 Not Acceptable" error from upyun server.  

After comparing the md5 hash generated from function makeContentMD5 with the result obtained from md5 command shipped with os, I realized that makeContentMD5 produced incorrect hashes consistently.  It turns out that incorrect size is used when the number of bytes read from file is less than the size of chunk, which usually happens during the last round of execution of the loop before reaching EOF.

BTW, thanks a lot for the wonderful SDK. :)