### PR TITLE
Pull request for the fix for makeContentMD5

### DIFF
--- a/upyun/upyun.go
+++ b/upyun/upyun.go
@@ -184,7 +184,7 @@ func (u *UpYun) makeContentMD5(value *os.File) (string, error) {
 		if n == 0 {
 			break
 		}
-		hasher.Write(chunk)
+		hasher.Write(chunk[0:n])
 	}
 
 	if _, err := value.Seek(0, 0); err != nil {


### PR DESCRIPTION
I enabled md5 verification this afternoon but I kept getting "Error: 406 Not Acceptable" error from upyun server.

After comparing the md5 hash generated from function makeContentMD5 with the result obtained from md5 command shipped with os, I realized that makeContentMD5 produced incorrect hashes consistently. It turns out that incorrect size is used when the number of bytes read from file is less than the size of chunk, which usually happens during the last round of execution of the loop before reaching EOF.