### PR TITLE
Add purge API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/upyun/go-sdk.svg?branch=master)](https://travis-ci.org/upyun/go-sdk)
 
-For UPYUN URL purge API, please check out [upyunpurge](blob/master/upyunpurge/README.md).
+For UPYUN URL purge API, please check out [upyunpurge](upyunpurge/README.md).
 
 ### 常量
 ```

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build Status](https://travis-ci.org/upyun/go-sdk.svg?branch=master)](https://travis-ci.org/upyun/go-sdk)
 
+For UPYUN URL purge API, please check out [upyunpurge](blob/master/upyunpurge/README.md).
+
 ### 常量
 ```
 const (

--- a/upyunpurge/README.md
+++ b/upyunpurge/README.md
@@ -1,0 +1,37 @@
+#Purpose
+
+With this library, you can call upyun cache refresh API to "purge" the old version of your files out of upyun system. 
+
+#Features
+Because upyun imposes a limit for how many urls one can purge for a minute, this library will send urls in batches and wait for 80 seconds before sending the next batch.
+
+Currently, the limit is 600 URLs per minute, and the batch size is 550.
+
+#How to use
+
+```go
+import (
+    "github.com/luanzhu/go-sdk/upyunpurge"
+    "log"
+    "fmt"
+)
+
+
+func refreshURLs(bucket, username, passwd string, urls []string) {
+	u := NewUpYunPurge(bucket, username, passwd)
+
+	invalidURLs, err := u.RefreshURLs(urls)
+	if err != nil {
+		// err contains the error message returned from server
+		log.Fatal(err)
+	} else {
+		// If there is no error, invalidURLs contains a list of URLs that upyun
+		// cannot process, which usually means that these URLs are not in 
+        // current bucket.
+		fmt.Println(invalidURLs)
+	}
+}
+```
+
+
+

--- a/upyunpurge/README.md
+++ b/upyunpurge/README.md
@@ -11,7 +11,7 @@ Currently, the limit is 600 URLs per minute, and the batch size is 550.
 
 ```go
 import (
-    "github.com/luanzhu/go-sdk/upyunpurge"
+    "github.com/upyun/go-sdk/upyunpurge"
     "log"
     "fmt"
 )

--- a/upyunpurge/README.md
+++ b/upyunpurge/README.md
@@ -20,7 +20,7 @@ import (
 func refreshURLs(bucket, username, passwd string, urls []string) {
 	u := NewUpYunPurge(bucket, username, passwd)
 
-	invalidURLs, err := u.RefreshURLs(urls)
+	invalidURLs, purgedURLs, err := u.PurgeURLs(urls)
 	if err != nil {
 		// err contains the error message returned from server
 		log.Fatal(err)
@@ -28,7 +28,12 @@ func refreshURLs(bucket, username, passwd string, urls []string) {
 		// If there is no error, invalidURLs contains a list of URLs that upyun
 		// cannot process, which usually means that these URLs are not in 
         // current bucket.
-		fmt.Println(invalidURLs)
+		fmt.Println("invalidURLs: ", invalidURLs)
+
+        // Because URLs may be sent in batches, purgedURLs contains the URLs that
+        // were sent to upyun without error.
+        // Items in invalidURLs will also appear here.
+        fmt.Println("purgedURLs:", purgedURLs)
 	}
 }
 ```

--- a/upyunpurge/ingroupof.go
+++ b/upyunpurge/ingroupof.go
@@ -1,0 +1,43 @@
+package upyunpurge
+
+// Separate a slice into sub-slices with length of n, except for
+// the last sub-slice, whose length may be less than n.
+// For example:
+//   InGroupOf([]{ "a", "b", "c", "d", "e"}, 2) =
+//      [][]string{{"a", "b"}, {"c", "d"}, {"e"}}
+func InGroupOf(items []string, n int) [][]string {
+	size := len(items)
+
+	division := size / n
+	modulo := size % n
+
+	newSize := division
+	if modulo > 0 {
+		newSize += 1
+	}
+
+	list := make([][]string, newSize)
+	for i := 0; i < newSize; i++ {
+		start := i * n
+		end := (i + 1) * n
+		if end > size {
+			end = size
+		}
+		list[i] = items[start:end]
+	}
+
+	return list
+}
+
+// Merge sub-slices into a slice.
+// For example:
+//   ConcatSubGroups([][]string{ {"a", "b"}, {"c"}}) =
+//      []String{"a", "b", "c"}
+func ConcatSubGroups(listOfList [][]string) []string {
+	finalList := make([]string, 0)
+	for _, items := range listOfList {
+		finalList = append(finalList, items...)
+	}
+
+	return finalList
+}

--- a/upyunpurge/ingroupof_test.go
+++ b/upyunpurge/ingroupof_test.go
@@ -1,0 +1,27 @@
+package upyunpurge
+
+import (
+	"github.com/stretchr/testify/assert"
+	"strconv"
+	"testing"
+)
+
+func TestInGroupOF(t *testing.T) {
+	n := 100
+
+	numbers := make([]string, n)
+	for i := 0; i < n; i++ {
+		numbers[i] = strconv.Itoa(i)
+	}
+
+	for i := 1; i < n+2; i++ {
+		r := InGroupOf(numbers, i)
+
+		newNumbers := ConcatSubGroups(r)
+
+		assert.Equal(t, len(numbers), len(newNumbers))
+		for m := 0; m < len(numbers); m++ {
+			assert.Equal(t, numbers[m], newNumbers[m])
+		}
+	}
+}

--- a/upyunpurge/purge.go
+++ b/upyunpurge/purge.go
@@ -1,0 +1,153 @@
+package upyunpurge
+
+import (
+	"bytes"
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	endpoint = "http://purge.upyun.com/purge/"
+	timeout  = 60
+)
+
+type UpYunPurge struct {
+	httpClient *http.Client
+
+	Bucket   string
+	Username string
+	Passwd   string
+
+	Timeout int
+}
+
+func stringMD5(s string) (string, error) {
+	hasher := md5.New()
+	if _, err := hasher.Write([]byte(s)); err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+func genRFC1123Date() string { return time.Now().UTC().Format(time.RFC1123) }
+
+func encodeURL(uri string) (string, error) {
+	Url, err := url.Parse(uri)
+	if err != nil {
+		return "", err
+	}
+
+	return Url.String(), nil
+}
+
+func timeoutDialer(timeout int) func(string, string) (net.Conn, error) {
+	return func(network, addr string) (c net.Conn, err error) {
+		c, err = net.DialTimeout(network, addr, time.Duration(timeout)*time.Second)
+		if err != nil {
+			return nil, err
+		}
+		return c, err
+	}
+}
+
+func NewUpYunPurge(bucket, username, passwd string) *UpYunPurge {
+	u := new(UpYunPurge)
+	u.Bucket = bucket
+	u.Username = username
+	u.Passwd = passwd
+
+	u.Timeout = timeout
+
+	u.httpClient = &http.Client{}
+	u.SetTimeout(u.Timeout)
+
+	return u
+}
+
+func (u *UpYunPurge) makeSignature(urls string, date string) (string, error) {
+	passwdMD5, err := stringMD5(u.Passwd)
+	if err != nil {
+		return "", err
+	}
+
+	signature := []string{urls, u.Bucket, date, passwdMD5}
+	signatureString := strings.Join(signature, "&")
+	signatureMD5, err := stringMD5(signatureString)
+	if err != nil {
+		return "", err
+	}
+
+	return signatureMD5, nil
+}
+
+func (u *UpYunPurge) makeAuth(sig string) string {
+	return "UpYun " + u.Bucket + ":" + u.Username + ":" + sig
+}
+
+func (u *UpYunPurge) Version() string { return "0.1.0" }
+
+func (u *UpYunPurge) SetTimeout(t int) {
+	tranport := http.Transport{
+		Dial: timeoutDialer(t),
+	}
+
+	u.httpClient = &http.Client{
+		Transport: &tranport,
+	}
+}
+
+func (u *UpYunPurge) RefreshURLs(urls []string) error {
+	method := "POST"
+
+	urlsString := strings.Join(urls, "\n")
+
+	body := "purge=" + urlsString
+	body, err := encodeURL(body)
+	if err != nil {
+		return err
+	}
+
+	date := genRFC1123Date()
+
+	sig, err := u.makeSignature(urlsString, date)
+	if err != nil {
+		return err
+	}
+
+	auth := u.makeAuth(sig)
+
+	req, err := http.NewRequest(method, endpoint, bytes.NewBufferString(body))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Add("Expect", "")
+	req.Header.Add("Date", date)
+	req.Header.Add("Authorization", auth)
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := u.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	reply, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode == 200 {
+		return nil
+	} else {
+		return fmt.Errorf("%d: %s", resp.StatusCode, string(reply))
+	}
+}

--- a/upyunpurge/purge_test.go
+++ b/upyunpurge/purge_test.go
@@ -1,6 +1,7 @@
 package upyunpurge
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -16,9 +17,11 @@ func TestUpyunPurge(t *testing.T) {
 
 	u := NewUpYunPurge(bucket, username, passwd)
 
-	err := u.RefreshURLs(urls)
+	invalidURLs, err := u.RefreshURLs(urls)
 
 	if err != nil {
 		t.Error(err)
+	} else {
+		fmt.Println(invalidURLs)
 	}
 }

--- a/upyunpurge/purge_test.go
+++ b/upyunpurge/purge_test.go
@@ -17,11 +17,12 @@ func TestUpyunPurge(t *testing.T) {
 
 	u := NewUpYunPurge(bucket, username, passwd)
 
-	invalidURLs, err := u.RefreshURLs(urls)
+	invalidURLs, purgedURLs, err := u.PurgeURLs(urls)
 
 	if err != nil {
 		t.Error(err)
 	} else {
-		fmt.Println(invalidURLs)
+		fmt.Println("invalidURLs:", invalidURLs)
+		fmt.Println("purgedURLs:", purgedURLs)
 	}
 }

--- a/upyunpurge/purge_test.go
+++ b/upyunpurge/purge_test.go
@@ -1,0 +1,24 @@
+package upyunpurge
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestUpyunPurge(t *testing.T) {
+	bucket := os.Getenv("UPYUN_BUCKET")
+	username := os.Getenv("UPYUN_USERNAME")
+	passwd := os.Getenv("UPYUN_PASSWORD")
+	urlsString := os.Getenv("UPYUN_URLS")
+
+	urls := strings.Split(urlsString, ",")
+
+	u := NewUpYunPurge(bucket, username, passwd)
+
+	err := u.RefreshURLs(urls)
+
+	if err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
This pull request is for adding upyun purge API.  

I have been using this for a couple of days and it seems to be working, well, most of the times.  Sometimes, I got errors complaining about "bucket does not exist" with a newly created bucket.  It is kind of strange because the same requests would succeed without errors the other times.  I suspect it is a sync issue between upyun servers because I never got error messages with an old bucket.  I am sure you have more insights into how purge works in your system and whether this component will work with your back-end servers.

Thanks!