### PR TITLE
fix bug when httpcode != 2xx and body length is 0

### DIFF
--- a/upyun/upyun-rest-api.go
+++ b/upyun/upyun-rest-api.go
@@ -211,12 +211,12 @@ func (u *UpYun) GetLargeList(key string, recursive bool) chan *FileInfo {
 		var listDir func(k string)
 		listDir = func(k string) {
 			iter := ""
-			limit := 100
+			limit := 50
 			for {
 				var niter string
 				infos, niter, err = u.loopList(k, iter, limit)
 				if err != nil {
-					continue
+					return
 				}
 				iter = niter
 				for _, f := range infos {
@@ -382,6 +382,9 @@ func (u *UpYun) doRESTRequest(method, uri string, headers map[string]string,
 	}
 
 	if body, err := ioutil.ReadAll(resp.Body); err == nil {
+		if len(body) == 0 && resp.StatusCode/100 != 2 {
+			return "", resp.Header, errors.New(fmt.Sprint(resp.StatusCode))
+		}
 		return "", resp.Header, errors.New(string(body))
 	} else {
 		return "", resp.Header, err


### PR DESCRIPTION
当 httpcode 非200时，并且 http body 为空，将错误信息设置成 httpcode