### PR TITLE
quick fix for invalid json resp

### DIFF
--- a/upyun/upyun-rest-api.go
+++ b/upyun/upyun-rest-api.go
@@ -307,7 +307,8 @@ func (u *UpYun) Purge(urls []string) (string, error) {
 	if resp.StatusCode/100 == 2 {
 		result := make(map[string][]string)
 		if err := json.Unmarshal(content, &result); err != nil {
-			return "", err
+			// quick fix for invalid json resp: {"invalid_domain_of_url":{}}
+			return "", nil
 		}
 
 		return strings.Join(result["invalid_domain_of_url"], ","), nil


### PR DESCRIPTION
调用purge API时，因为又拍API服务器返回JSON格式不正确导致解释错误：
json: cannot unmarshal object into Go value of type []string
exit status 1

正确的返回应为：{"invalid_domain_of_url":[]}
而又拍的服务器返回是：{"invalid_domain_of_url":{}}