### PR TITLE
fix: GetList called in a file

### DIFF
--- a/upyun/upyun-rest-api.go
+++ b/upyun/upyun-rest-api.go
@@ -174,6 +174,9 @@ func (u *UpYun) AsyncDelete(key string) error {
 // GetList lists items in key. The number of items must be
 // less then 100
 func (u *UpYun) GetList(key string) ([]*FileInfo, error) {
+	if fileinfo, err := u.GetInfo(key); (err != nil) || (fileinfo.Type != "folder") {
+		return nil, errors.New("Invalid Folder")
+	}
 	ret, _, err := u.doRESTRequest("GET", key, "", nil, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
对一个文件调用 GetList 会返回 [nil, nil, nil, nil ..... ]